### PR TITLE
Allow the Plugin to be used when using `-host-header=rewrite`

### DIFF
--- a/Plugin/Magento/Store/Model/Store.php
+++ b/Plugin/Magento/Store/Model/Store.php
@@ -19,9 +19,8 @@ class Store
      * Store constructor.
      * @param \Magento\Framework\App\State $state
      */
-    public function __construct(
-        \Magento\Framework\App\State $state
-    ) {
+    public function __construct(\Magento\Framework\App\State $state)
+    {
         $this->state = $state;
     }
 
@@ -32,8 +31,7 @@ class Store
      */
     protected function getProtocol()
     {
-        return
-            (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+        return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
             || $_SERVER['SERVER_PORT'] == 443 ? 'https://' : 'http://';
     }
 
@@ -54,14 +52,20 @@ class Store
      */
     public function afterGetBaseUrl(\Magento\Store\Model\Store $subject, $result)
     {
-        if(!$this->isDeveloperMode())
-        {
+        if(!$this->isDeveloperMode()) {
             return $result;
         }
 
-        if (isset($_SERVER['HTTP_HOST']) && strpos($_SERVER['HTTP_HOST'], self::NGROK_URL) && in_array($result, array($subject->getConfig($subject::XML_PATH_SECURE_BASE_URL), $subject->getConfig($subject::XML_PATH_UNSECURE_BASE_URL))))
-        {
-            return $this->getProtocol() . $_SERVER['HTTP_HOST'] . DIRECTORY_SEPARATOR;
+        if (isset($_SERVER['HTTP_HOST'])
+            && (strpos($_SERVER['HTTP_HOST'], self::NGROK_URL)
+            || strpos($_SERVER['HTTP_X_ORIGINAL_HOST'], self::NGROK_URL))
+            && in_array($result, array(
+                $subject->getConfig($subject::XML_PATH_SECURE_BASE_URL),
+                $subject->getConfig($subject::XML_PATH_UNSECURE_BASE_URL))
+            )) {
+            $httpHost = $_SERVER['HTTP_X_ORIGINAL_HOST'] ?: $_SERVER['HTTP_HOST'];
+            $_SERVER['HTTP_HOST'] = $httpHost;
+            return $this->getProtocol() . $httpHost . DIRECTORY_SEPARATOR;
         }
 
         return $result;


### PR DESCRIPTION
Currently using `ngrok http -host-header=rewrite dev.site:80` does not work with this plugin
as the `$_SERVER['HTTP_HOST']` is set to `http://dev.site` so will not be picked upt by current checks.

this commit Updates the `if` statement to also check `$_SERVER['HTTP_X_ORIGINAL_HOST']` for the `NGROK_URL`
and makes the necessary changes to deliver the correct base_url and therefore the correct assets.

the reason this is required is for multistore sites that set the mage_run_code based on the  URL.